### PR TITLE
Bug fix in zca_whitening calculation

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -275,7 +275,7 @@ class ImageDataGenerator(object):
 
         if self.zca_whitening:
             flatX = np.reshape(X, (X.shape[0], X.shape[1]*X.shape[2]*X.shape[3]))
-            sigma = np.dot(flatX.T, flatX) / flatX.shape[1]
+            sigma = np.dot(flatX.T, flatX) / flatX.shape[0]
             U, S, V = linalg.svd(sigma)
             self.principal_components = np.dot(np.dot(U, np.diag(1. / np.sqrt(S + 10e-7))), U.T)
 


### PR DESCRIPTION
When calculating 'sigma' denominator is # of instances (axis=0), not dimensionality (axis=1)

Proof:
http://ufldl.stanford.edu/wiki/index.php/Implementing_PCA/Whitening
http://ufldl.stanford.edu/wiki/index.php/Exercise:PCA_and_Whitening
Ng uses 2nd dim in denominator because his matrix is [features x instances]
